### PR TITLE
refactor: to produce post figures must call `run()` function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,18 @@ Currently two different datasets are being used for benchmarking and experiments
 
 
 # Figures and Plots
-All figures used for paper (and related documents, *e.g.*, project proposal) will be found in the `pydmdeep.post` submodule.
+All figures used for paper (and related documents, *e.g.*, project proposal) will be found in the `pydmdeep.post` subpackage.
 
 ## MWE: producing figures
+To construct all figures simply run
 ```python
-import pydmdeep.post
-pydmdeep.post
+import pydmdeep.post as post
+post.run()
+```
+
+Or run specific post submodules for specific figures, _i.e._, 
+```python
+post.propsal_figures.run()
 ```
 
 ![](images/toy_dataset.png)

--- a/pydmdeep/post/__init__.py
+++ b/pydmdeep/post/__init__.py
@@ -1,1 +1,7 @@
 from . import proposal_figures
+
+def run():
+    proposal_figures.run()
+
+if __name__=="__main__":
+    run()

--- a/pydmdeep/post/proposal_figures.py
+++ b/pydmdeep/post/proposal_figures.py
@@ -34,6 +34,9 @@ def plot_plumes_image():
     video, orig_center_fc = _load_video(data_lookup["filename"]["low-869"])
     plot_raw_frames(video=video[599:], n_frames=4, n_rows=1, n_cols=4)
 
+def run():
+    plot_toy_dataset()
+    plot_plumes_image()
 
-plot_toy_dataset()
-plot_plumes_image()
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
To avoid unexpected behavior, one must call `pydmdeep.post.run()` to produce all figures for proposal and report. Or run pydmdeep.post directly as a module via a CLI.